### PR TITLE
bump node to 20.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
     - run: |
         npm install -g @openfn/cli
         openfn deploy -c $OPENFN_CONFIG_PATH --no-confirm


### PR DESCRIPTION
**Description**
GitHub sync is failing when runing `npm install -g @openfn/cli` 👇🏽 . 
```bash
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'lru-cache@11.1.0',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
```
See [Failed run](https://github.com/OpenFn/msf-lime-mosul/actions/runs/16681451442/job/47220856586)

This PR update the node version from `18.x` to `20.x`

